### PR TITLE
fix deprecated warnings

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -207,7 +207,7 @@ impl<'de, R: Read<'de>> Deserializer<R> {
                 self.eat_char();
                 self.parse_integer(false)?.visit(visitor)
             }
-            b'0'...b'9' => self.parse_integer(true)?.visit(visitor),
+            b'0'..=b'9' => self.parse_integer(true)?.visit(visitor),
             b'"' => {
                 self.eat_char();
                 self.str_buf.clear();
@@ -234,7 +234,7 @@ impl<'de, R: Read<'de>> Deserializer<R> {
                     (Err(err), _) | (_, Err(err)) => Err(err),
                 }
             }
-            b'a'...b'z' | b'A'...b'Z' => {
+            b'a'..=b'z' | b'A'..=b'Z' => {
                 self.str_buf.clear();
                 match self.read.parse_symbol(&mut self.str_buf)? {
                     Reference::Borrowed(s) => visitor.visit_newtype_struct(Atom::from_str(s)),
@@ -271,16 +271,16 @@ impl<'de, R: Read<'de>> Deserializer<R> {
             b'0' => {
                 // There can be only one leading '0'.
                 match self.peek_or_null()? {
-                    b'0'...b'9' => Err(self.peek_error(ErrorCode::InvalidNumber)),
+                    b'0'..=b'9' => Err(self.peek_error(ErrorCode::InvalidNumber)),
                     _ => self.parse_number(pos, 0),
                 }
             }
-            c @ b'1'...b'9' => {
+            c @ b'1'..=b'9' => {
                 let mut res = u64::from(c - b'0');
 
                 loop {
                     match self.peek_or_null()? {
-                        c @ b'0'...b'9' => {
+                        c @ b'0'..=b'9' => {
                             self.eat_char();
                             let digit = u64::from(c - b'0');
 
@@ -313,7 +313,7 @@ impl<'de, R: Read<'de>> Deserializer<R> {
     ) -> Result<f64> {
         loop {
             match self.peek_or_null()? {
-                b'0'...b'9' => {
+                b'0'..=b'9' => {
                     self.eat_char();
                     // This could overflow... if your integer is gigabytes long.
                     // Ignore that possibility.
@@ -357,7 +357,7 @@ impl<'de, R: Read<'de>> Deserializer<R> {
         self.eat_char();
 
         let mut at_least_one_digit = false;
-        while let c @ b'0'...b'9' = self.peek_or_null()? {
+        while let c @ b'0'..=b'9' = self.peek_or_null()? {
             self.eat_char();
             let digit = u64::from(c - b'0');
             at_least_one_digit = true;
@@ -365,7 +365,7 @@ impl<'de, R: Read<'de>> Deserializer<R> {
             if overflow!(significand * 10 + digit, u64::MAX) {
                 // The next multiply/add would overflow, so just ignore all
                 // further digits.
-                while let b'0'...b'9' = self.peek_or_null()? {
+                while let b'0'..=b'9' = self.peek_or_null()? {
                     self.eat_char();
                 }
                 break;
@@ -745,7 +745,7 @@ where
                         Reference::Copied(s) => visitor.visit_str(s),
                     }
                 }
-                b'a'...b'z' | b'A'...b'Z' => {
+                b'a'..=b'z' | b'A'..=b'Z' => {
                     self.de.str_buf.clear();
                     match self.de.read.parse_symbol(&mut self.de.str_buf)? {
                         Reference::Borrowed(s) => visitor.visit_borrowed_str(s),

--- a/src/error.rs
+++ b/src/error.rs
@@ -331,7 +331,7 @@ impl error::Error for Error {
         }
     }
 
-    fn cause(&self) -> Option<&error::Error> {
+    fn cause(&self) -> Option<&dyn error::Error> {
         match self.err.code {
             ErrorCode::Io(ref err) => Some(err),
             _ => None,

--- a/src/read.rs
+++ b/src/read.rs
@@ -575,13 +575,13 @@ fn parse_escape<'de, R: Read<'de>>(read: &mut R, scratch: &mut Vec<u8>) -> Resul
         b't' => scratch.push(b'\t'),
         b'u' => {
             let c = match decode_hex_escape(read)? {
-                0xDC00...0xDFFF => {
+                0xDC00..=0xDFFF => {
                     return error(read, ErrorCode::LoneLeadingSurrogateInHexEscape);
                 }
 
                 // Non-BMP characters are encoded as a sequence of
                 // two hex escapes, representing UTF-16 surrogates.
-                n1 @ 0xD800...0xDBFF => {
+                n1 @ 0xD800..=0xDBFF => {
                     if next_or_eof(read)? != b'\\' {
                         return error(read, ErrorCode::UnexpectedEndOfHexEscape);
                     }
@@ -631,7 +631,7 @@ fn decode_hex_escape<'de, R: Read<'de>>(read: &mut R) -> Result<u16> {
     let mut n = 0;
     for _ in 0..4 {
         n = match next_or_eof(read)? {
-            c @ b'0'...b'9' => n * 16_u16 + (u16::from(c) - u16::from(b'0')),
+            c @ b'0'..=b'9' => n * 16_u16 + (u16::from(c) - u16::from(b'0')),
             b'a' | b'A' => n * 16_u16 + 10_u16,
             b'b' | b'B' => n * 16_u16 + 11_u16,
             b'c' | b'C' => n * 16_u16 + 12_u16,


### PR DESCRIPTION
* `...` in patterns is deprecated, and `..=` is recommended instead
* `Option<&error::Error>` is deprecated, and `Option<&dyn error::Error>` is recommended instead

These are all deprecated warnings in my environment, and I fixed.